### PR TITLE
Maak swarm robuuster

### DIFF
--- a/.swarm/dl_and_load_data.sh
+++ b/.swarm/dl_and_load_data.sh
@@ -8,3 +8,5 @@ docker exec $_db_docker psql -U panorama -c 'delete from panoramas_region'
 docker exec $_db_docker psql -U panorama -c 'create sequence panoramas_region_id_seq'
 docker exec $_db_docker psql -U panorama -c "alter table panoramas_region alter id set default nextval('panoramas_region_id_seq')"
 docker exec $_db_docker /bin/update-table.sh panorama panoramas_panorama public panorama
+docker exec $_db_docker psql -U panorama -c "delete from panoramas_panorama where status='done'"
+docker exec $_db_docker rm /tmp/panorama_latest.gz

--- a/.swarm/docker-compose.yml
+++ b/.swarm/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       DATABASE_PASSWORD: insecure
       ON_SWARM: 1
     deploy:
-      replicas: 32
+      replicas: 1
       placement:
         constraints:
           - node.hostname != master.swarm.datapunt.amsterdam.nl

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Je kunt ook het project lokaal op poort 8000 draaien, maar dat vereist op zijn m
 	
 Importeer de meest recente database van acceptatie:
 
-	docker-compose exec database update-db.sh panorama
+	docker-compose exec database update-db.sh panorama <your_username>
 	
 Unit tests lokaal draaien
 -------------------------


### PR DESCRIPTION
Aanpassingen in opstarten swarm:
- minder replica's starten, om te beginnen (geeft meer ruimte aan
  opstart DB)
- meer tijd geven aan DB om up te komen
- na dl_and_load opruimen in de DB, voordat de swarm opschaalt