### PR TITLE
Rollback slow view

### DIFF
--- a/web/panorama/datasets/panoramas/migrations/0032_readd_recent_views.py
+++ b/web/panorama/datasets/panoramas/migrations/0032_readd_recent_views.py
@@ -13,9 +13,15 @@ views_recent_pano = [
         view_name="panoramas_recent_ids_all",
         sql="""
 SELECT pano_id FROM panoramas_panorama p
-WHERE p.status = 'done' AND NOT EXISTS (
-    SELECT * FROM panoramas_panorama n WHERE n.status = 'done' AND n.mission_distance = p.mission_distance
-    AND n.timestamp > p.timestamp AND ST_DWithin(n._geolocation_2d_rd, p._geolocation_2d_rd, n.mission_distance - 0.7)
+WHERE p.status = 'done' AND p.surface_type = 'L' AND NOT EXISTS (
+    SELECT * FROM panoramas_panorama n WHERE n.status = 'done' AND n.surface_type = 'L'
+    AND n.timestamp > p.timestamp AND ST_DWithin(n._geolocation_2d_rd, p._geolocation_2d_rd, 4.3)
+)
+UNION
+SELECT pano_id FROM panoramas_panorama p
+WHERE p.status = 'done' AND p.surface_type = 'W' AND NOT EXISTS (
+    SELECT * FROM panoramas_panorama n WHERE n.status = 'done' AND n.surface_type = 'W'
+    AND n.timestamp > p.timestamp AND ST_DWithin(n._geolocation_2d_rd, p._geolocation_2d_rd, 9.3)
 )
 ORDER BY 1
 """

--- a/web/panorama/panorama/batch.py
+++ b/web/panorama/panorama/batch.py
@@ -74,13 +74,13 @@ class ImportPanoramaJob(object):
                 self.process_csv(csv_file, self.process_panorama_row, with_mission=True),
                 batch_size=BATCH_SIZE
             )
-
-        for csv_file in self.object_store.get_csvs('trajectory'):
-            log.info('READING trajectory: %s', csv_file['name'])
-            Traject.objects.bulk_create(
-                self.process_csv(csv_file, self.process_traject_row),
-                batch_size=BATCH_SIZE
-            )
+        #
+        # for csv_file in self.object_store.get_csvs('trajectory'):
+        #     log.info('READING trajectory: %s', csv_file['name'])
+        #     Traject.objects.bulk_create(
+        #         self.process_csv(csv_file, self.process_traject_row),
+        #         batch_size=BATCH_SIZE
+        #     )
 
     def process_csv(self, csv_file, process_row_callback, *args, **kwargs):
         """

--- a/web/panorama/panorama/tests/test_batch.py
+++ b/web/panorama/panorama/tests/test_batch.py
@@ -91,8 +91,8 @@ class ImportPanoTest(TransactionTestCase):
         self.assertIsNotNone(panos[0]._geolocation_2d_rd)
         self.assertAlmostEqual(panos[0]._geolocation_2d_rd, panos[0]._geolocation_2d.transform(28992, clone=True))
 
-        trajecten = Traject.objects.all()
-        self.assertEqual(trajecten.count(), 16)
+        # trajecten = Traject.objects.all()
+        # self.assertEqual(trajecten.count(), 16)
 
         adjecencies = Adjacency.objects.all()
         self.assertEqual(adjecencies.count(), 12)


### PR DESCRIPTION
Part of DP-6022

The change in database migrate scripts resulted in a very slow creation
of the MATERIALIZED VIEW panoramas_recent_all, this rolls back the
changes, allowing for front-end devlopment. Unused import of trajectory
is disabled.