### PR TITLE
Get mission_year from timestamp of panorama

### DIFF
--- a/web/panorama/datasets/panoramas/serializers_new.py
+++ b/web/panorama/datasets/panoramas/serializers_new.py
@@ -51,7 +51,7 @@ class AdjacentLink(PanoLinksFieldNew):
     """
     def to_representation(self, value):
         request = self.context.get('request')
-        href = f"{request.build_absolute_uri()}{value.from_pano_id}/"
+        href = f"{request.build_absolute_uri(request.path)}{value.from_pano_id}/"
         return dict(href=href)
 
 

--- a/web/panorama/panorama/batch.py
+++ b/web/panorama/panorama/batch.py
@@ -159,15 +159,17 @@ class ImportPanoramaJob(object):
         # Creating unique id from mission id and pano id
         pano_id = '%s_%s' % (path.split('/')[-2], base_filename)
 
+        pano_timestamp = self._convert_gps_time(row['gps_seconds[s]'])
+
         return Panorama(
             pano_id=pano_id,
             status=pano_status,
-            timestamp=self._convert_gps_time(row['gps_seconds[s]']),
+            timestamp=pano_timestamp,
             filename=pano_image,
             path=container+'/'+path,
             mission_type=mission.mission_type,
             surface_type=mission.surface_type,
-            mission_year=mission.mission_year,
+            mission_year=pano_timestamp.year,
             mission_distance=mission.mission_distance,
             geolocation=Point(
                 float(row['longitude[deg]']),

--- a/web/panorama/panorama/batch.py
+++ b/web/panorama/panorama/batch.py
@@ -16,6 +16,7 @@ from datasets.panoramas.models import Panorama, Traject, Mission
 from datasets.panoramas.models import EQUIRECTANGULAR_SUBPATH, FULL_IMAGE_NAME
 from panorama.shared.object_store import ObjectStore
 
+EMPTY_FALLBACK_YEAR = 2000
 BATCH_SIZE = 50000
 log = logging.getLogger(__name__)
 
@@ -111,7 +112,7 @@ class ImportPanoramaJob(object):
                     mission_distance=5,
                     date="2015-1-1",
                     neighbourhood='AUTOMATICALLY CREATED',
-                    mission_year=2015
+                    mission_year=EMPTY_FALLBACK_YEAR
                 )
                 mission.save()
         else:
@@ -160,6 +161,7 @@ class ImportPanoramaJob(object):
         pano_id = '%s_%s' % (path.split('/')[-2], base_filename)
 
         pano_timestamp = self._convert_gps_time(row['gps_seconds[s]'])
+        mission_year = pano_timestamp.year if mission.mission_year == EMPTY_FALLBACK_YEAR else mission.mission_year
 
         return Panorama(
             pano_id=pano_id,
@@ -169,7 +171,7 @@ class ImportPanoramaJob(object):
             path=container+'/'+path,
             mission_type=mission.mission_type,
             surface_type=mission.surface_type,
-            mission_year=pano_timestamp.year,
+            mission_year=mission_year,
             mission_distance=mission.mission_distance,
             geolocation=Point(
                 float(row['longitude[deg]']),

--- a/web/panorama/panorama/tests/test_batch.py
+++ b/web/panorama/panorama/tests/test_batch.py
@@ -109,7 +109,7 @@ class ImportPanoTest(TransactionTestCase):
         self.assertEqual(Panorama.objects.filter(pano_id='TMX7315120208-000033_pano_0000_006658')[0].mission_type, 'bi')
         self.assertEqual(Panorama.objects.filter(pano_id='TMX7315120208-000067_pano_0011_000463')[0].mission_type, 'woz')
 
-        self.assertEqual(Panorama.objects.filter(pano_id='TMX7315120208-000032_pano_0000_007572')[0].mission_year, 2015)
+        self.assertEqual(Panorama.objects.filter(pano_id='TMX7315120208-000032_pano_0000_007572')[0].mission_year, 2016)
         self.assertEqual(Panorama.objects.filter(pano_id='TMX7315120208-000067_pano_0011_000463')[0].mission_year, 2016)
         self.assertEqual(Panorama.objects.filter(pano_id='TMX7315120208-000073_pano_0004_000087')[0].mission_year, 2017)
 


### PR DESCRIPTION
Part of DP-6022

The mission year was read from missions.csv and for missing missions was
set to the arbitrary value of 2015. This didn't matter because for
filtering the date in timestamp was used. But when adding mission_year
to panorama it became a way to filter. This change sets the mission_year
to the year of the timestamp of the panorama, even if the mission is not
known.