### PR TITLE
Add (relative) elevation to adjacency

### DIFF
--- a/web/panorama/datasets/panoramas/migrations/0035_add_panoramas_adjacencies_new.py
+++ b/web/panorama/datasets/panoramas/migrations/0035_add_panoramas_adjacencies_new.py
@@ -36,6 +36,7 @@ class Migration(migrations.Migration):
                     relative_distance,
                     relative_heading,
                     relative_pitch,
+                    relative_elevation,
 
                     from_geolocation_2d_rd,
 

--- a/web/panorama/datasets/panoramas/models_new.py
+++ b/web/panorama/datasets/panoramas/models_new.py
@@ -132,6 +132,7 @@ class Adjacencies(AbstractPanoramaNew):
     relative_distance = models.FloatField()
     relative_pitch = models.FloatField()
     relative_heading = models.FloatField()
+    relative_elevation = models.FloatField()
 
     class Meta(AbstractPanoramaNew.Meta):
         abstract = False

--- a/web/panorama/datasets/panoramas/serializers_new.py
+++ b/web/panorama/datasets/panoramas/serializers_new.py
@@ -70,6 +70,7 @@ class AdjacentPanoSerializer(PanoSerializerNew):
     distance = serializers.DecimalField(max_digits=20, decimal_places=2, source='relative_distance')
     direction = serializers.DecimalField(max_digits=20, decimal_places=2, source='relative_heading')
     angle = serializers.DecimalField(max_digits=20, decimal_places=2, source='relative_pitch')
+    elevation = serializers.DecimalField(max_digits=20, decimal_places=2, source='relative_elevation')
 
     class Meta(PanoSerializerNew.Meta):
         listresults_field = 'adjacencies'


### PR DESCRIPTION
Part of DP-6135

Added the attribute elevation (difference in height between panorama and
adjacent panorama), this will make taken the relative height into
account for hotspots in the frontend as easy as replacing:
`hotspotPitch = calculateHotspotPitch(STRAATBEELD_CONFIG.CAMERA_HEIGHT,
hotspot.distance);`
with
`hotspotPitch =
calculateHotspotPitch(STRAATBEELD_CONFIG.CAMERA_HEIGHT-hotspot.elevation,
hotspot.distance);`

for `calculateHotspotPitch` as `Math.atan(height / distance);`