### PR TITLE
Add sentry to panorama project

### DIFF
--- a/web/panorama/panorama/settings.py
+++ b/web/panorama/panorama/settings.py
@@ -1,5 +1,8 @@
 import os
 
+import sentry_sdk
+from sentry_sdk.integrations.django import DjangoIntegration
+
 from panorama import objectstore_settings
 from panorama.settings_common import * # noqa F403
 from panorama.settings_common import INSTALLED_APPS, DEBUG, DATAPUNT_API_URL
@@ -70,6 +73,13 @@ STATIC_URL = '/static/'
 STATIC_ROOT = os.path.abspath(os.path.join(BASE_DIR, '..', 'static'))
 
 HEALTH_MODEL = 'panoramas.Panorama'
+
+SENTRY_DSN = os.getenv('SENTRY_DSN')
+if SENTRY_DSN:
+    sentry_sdk.init(
+        dsn=SENTRY_DSN,
+        integrations=[DjangoIntegration()]
+    )
 
 # Set of years to group panoramas by
 PREPARED_YEARS = range(2016, 2021)

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -62,6 +62,7 @@ requests==2.20.1
 rfc3986==1.2.0
 rsa==4.0
 scipy==1.1.0
+sentry-sdk==0.6.6
 simplejson==3.16.0
 six==1.11.0
 sqlparse==0.2.4

--- a/web/root-requirements.txt
+++ b/web/root-requirements.txt
@@ -18,3 +18,4 @@ psycopg2-binary
 python-keystoneclient
 python-swiftclient
 scipy
+sentry-sdk


### PR DESCRIPTION
Sentry is an application (error) logging framework for (amongst others)
python. At DataPunt Amsterdam it is used to monitor our applications.
This adds the connection to the sentry server, and DjangoIntegration.