### PR TITLE
Only default missiontype ('bi') in recent panoramas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ reports
 *_dev_settings.py
 web/static/*
 .env
+.venv
 .jenkins/backups
 /panoramas_test
 test_output

--- a/web/panorama/datasets/panoramas/migrations/0033_readd_recent_views.py
+++ b/web/panorama/datasets/panoramas/migrations/0033_readd_recent_views.py
@@ -13,14 +13,14 @@ views_recent_pano = [
         view_name="panoramas_recent_ids_all",
         sql="""
 SELECT pano_id FROM panoramas_panorama p
-WHERE p.status = 'done' AND p.surface_type = 'L' AND NOT EXISTS (
-    SELECT * FROM panoramas_panorama n WHERE n.status = 'done' AND n.surface_type = 'L'
+WHERE p.status = 'done' AND p.surface_type = 'L' AND p.mission_type = 'bi' AND NOT EXISTS (
+    SELECT * FROM panoramas_panorama n WHERE n.status = 'done' AND n.surface_type = 'L' AND n.mission_type = 'bi' 
     AND n.timestamp > p.timestamp AND ST_DWithin(n._geolocation_2d_rd, p._geolocation_2d_rd, 4.3)
 )
 UNION
 SELECT pano_id FROM panoramas_panorama p
-WHERE p.status = 'done' AND p.surface_type = 'W' AND NOT EXISTS (
-    SELECT * FROM panoramas_panorama n WHERE n.status = 'done' AND n.surface_type = 'W'
+WHERE p.status = 'done' AND p.surface_type = 'W' AND p.mission_type = 'bi' AND NOT EXISTS (
+    SELECT * FROM panoramas_panorama n WHERE n.status = 'done' AND n.surface_type = 'W' AND n.mission_type = 'bi' 
     AND n.timestamp > p.timestamp AND ST_DWithin(n._geolocation_2d_rd, p._geolocation_2d_rd, 9.3)
 )
 ORDER BY 1

--- a/web/panorama/datasets/panoramas/serializers.py
+++ b/web/panorama/datasets/panoramas/serializers.py
@@ -11,8 +11,6 @@ from rest_framework_gis import fields
 from datasets.panoramas import models, models_new
 from datapunt_api.rest import LinksField, HALSerializer
 
-from panorama.views_new import RawCol
-
 log = logging.getLogger(__name__)
 
 MAX_ADJACENCY = 21
@@ -34,11 +32,11 @@ class AdjacencySerializer(serializers.ModelSerializer):
         fields = ('pano_id', 'direction', 'angle', 'heading', 'pitch', 'distance', 'year',)
 
     def get_direction(self, instance):
-        "Unused - meaningless parameter, forcefully set to null"
+        # Unused - meaningless parameter, forcefully set to null
         return None
 
     def get_angle(self, instance):
-        "Unused - meaningless parameter, forcefully set to null"
+        # Unused - meaningless parameter, forcefully set to null
         return None
 
 

--- a/web/panorama/panorama/settings.py
+++ b/web/panorama/panorama/settings.py
@@ -1,11 +1,9 @@
-import os
-
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
 
 from panorama import objectstore_settings
 from panorama.settings_common import * # noqa F403
-from panorama.settings_common import INSTALLED_APPS, DEBUG, DATAPUNT_API_URL
+from panorama.settings_common import INSTALLED_APPS
 from panorama.settings_databases import LocationKey, \
     get_docker_host, \
     get_database_key, \

--- a/web/panorama/panorama/shared/object_store.py
+++ b/web/panorama/panorama/shared/object_store.py
@@ -22,7 +22,7 @@ class ObjectStore(object):
                                                auth_version=settings.AUTH_VERSION,
                                                os_options={'tenant_id': settings.DATAPUNT_TENANT_ID,
                                                            'region_name': settings.REGION_NAME,
-                                                           'endpoint_type': 'internalURL'
+                                                           # 'endpoint_type': 'internalURL'
                                                            })
         self.panorama_conn = client.Connection(authurl=settings.AUTHURL,
                                                user=settings.OBJECTSTORE_USER,
@@ -31,7 +31,7 @@ class ObjectStore(object):
                                                auth_version=settings.AUTH_VERSION,
                                                os_options={'tenant_id': settings.PANORAMA_TENANT_ID,
                                                            'region_name': settings.REGION_NAME,
-                                                           'endpoint_type': 'internalURL'
+                                                           # 'endpoint_type': 'internalURL'
                                                            })
 
     def get_panorama_store_object(self, object_meta_data):

--- a/web/panorama/panorama/shared/object_store.py
+++ b/web/panorama/panorama/shared/object_store.py
@@ -22,7 +22,7 @@ class ObjectStore(object):
                                                auth_version=settings.AUTH_VERSION,
                                                os_options={'tenant_id': settings.DATAPUNT_TENANT_ID,
                                                            'region_name': settings.REGION_NAME,
-                                                           # 'endpoint_type': 'internalURL'
+                                                           'endpoint_type': 'internalURL'
                                                            })
         self.panorama_conn = client.Connection(authurl=settings.AUTHURL,
                                                user=settings.OBJECTSTORE_USER,
@@ -31,7 +31,7 @@ class ObjectStore(object):
                                                auth_version=settings.AUTH_VERSION,
                                                os_options={'tenant_id': settings.PANORAMA_TENANT_ID,
                                                            'region_name': settings.REGION_NAME,
-                                                           # 'endpoint_type': 'internalURL'
+                                                           'endpoint_type': 'internalURL'
                                                            })
 
     def get_panorama_store_object(self, object_meta_data):

--- a/web/panorama/panorama/tests/test_api_base.py
+++ b/web/panorama/panorama/tests/test_api_base.py
@@ -31,6 +31,7 @@ class PanoramaApiTest(APITestCase):
             heading=factory.fuzzy.FuzzyFloat(-10, 10),
             mission_distance=5.0,
             mission_year=2014,
+            mission_type='bi',
             tags=[]
         )
         factories.PanoramaFactory.create(
@@ -46,6 +47,7 @@ class PanoramaApiTest(APITestCase):
             heading=factory.fuzzy.FuzzyFloat(-10, 10),
             mission_distance=5.0,
             mission_year=2014,
+            mission_type='bi',
             tags=[]
         )
         factories.PanoramaFactory.create(
@@ -61,6 +63,7 @@ class PanoramaApiTest(APITestCase):
             heading=factory.fuzzy.FuzzyFloat(-10, 10),
             mission_distance=5.0,
             mission_year=2015,
+            mission_type='bi',
             tags=[]
         )
         factories.PanoramaFactory.create(
@@ -76,6 +79,7 @@ class PanoramaApiTest(APITestCase):
             heading=factory.fuzzy.FuzzyFloat(-10, 10),
             mission_distance=5.0,
             mission_year=2014,
+            mission_type='bi',
             tags=[]
         )
         factories.PanoramaFactory.create(
@@ -91,6 +95,7 @@ class PanoramaApiTest(APITestCase):
             heading=factory.fuzzy.FuzzyFloat(-10, 10),
             mission_distance=5.0,
             mission_year=2015,
+            mission_type='bi',
             tags=[]
         )
         factories.PanoramaFactory.create(
@@ -105,6 +110,7 @@ class PanoramaApiTest(APITestCase):
             heading=factory.fuzzy.FuzzyFloat(-10, 10),
             mission_distance=5.0,
             mission_year=2016,
+            mission_type='bi',
             tags=[]
         )
         factories.PanoramaFactory.create(
@@ -119,6 +125,7 @@ class PanoramaApiTest(APITestCase):
             heading=factory.fuzzy.FuzzyFloat(-10, 10),
             mission_distance=5.0,
             mission_year=2016,
+            mission_type='bi',
             tags=[]
         )
         factories.PanoramaFactory.create(
@@ -133,6 +140,7 @@ class PanoramaApiTest(APITestCase):
             heading=factory.fuzzy.FuzzyFloat(-10, 10),
             mission_distance=5.0,
             mission_year=2017,
+            mission_type='bi',
             tags=[]
         )
         factories.PanoramaFactory.create(
@@ -147,6 +155,7 @@ class PanoramaApiTest(APITestCase):
             heading=factory.fuzzy.FuzzyFloat(-10, 10),
             mission_distance=5.0,
             mission_year=2017,
+            mission_type='bi',
             tags=[]
         )
 

--- a/web/panorama/panorama/tests/test_api_base.py
+++ b/web/panorama/panorama/tests/test_api_base.py
@@ -158,6 +158,21 @@ class PanoramaApiTest(APITestCase):
             mission_type='bi',
             tags=[]
         )
+        factories.PanoramaFactory.create(
+            pano_id='PANO_WOZ_2018',
+            status=Panorama.STATUS.done,
+            timestamp=datetime.datetime(2018, 5, 5, tzinfo=UTC_TZ),
+            filename=factory.fuzzy.FuzzyText(length=30),
+            path=factory.fuzzy.FuzzyText(length=30),
+            geolocation=Point(4.897071, 52.377956, 10),
+            roll=factory.fuzzy.FuzzyFloat(-10, 10),
+            pitch=factory.fuzzy.FuzzyFloat(-10, 10),
+            heading=factory.fuzzy.FuzzyFloat(-10, 10),
+            mission_distance=5.0,
+            mission_year=2018,
+            mission_type='woz',
+            tags=[]
+        )
 
         RefreshViews().refresh_views()
         time.sleep(2)

--- a/web/panorama/panorama/tests/test_api_recent.py
+++ b/web/panorama/panorama/tests/test_api_recent.py
@@ -10,7 +10,7 @@ class RecentPanoramaApiTest(PanoramaApiTest):
     def test_list_opnamelocaties(self):
         response = self.client.get('/panorama/opnamelocatie/')
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(7, len(response.data['results']))
+        self.assertEqual(8, len(response.data['results']))
 
     def test_list_recente_opnames(self):
         response = self.client.get('/panorama/recente_opnames/alle/')

--- a/web/panorama/panorama/tests/test_api_thumbnail.py
+++ b/web/panorama/panorama/tests/test_api_thumbnail.py
@@ -1,12 +1,40 @@
+# Python
+import datetime
+# Packages
+from django.contrib.gis.geos import Point
+from django.utils.timezone import utc as UTC_TZ
+import factory
+import factory.fuzzy
 # Project
 from . test_api_base import PanoramaApiTest
-
+from datasets.panoramas.models import Panorama
+from datasets.panoramas.tests import factories
 
 class ThumbnailApiTest(PanoramaApiTest):
 
+    @classmethod
+    def setUpClass(cls):
+        # Adding locations
+        factories.PanoramaFactory.create(
+            pano_id='PANO_WOZ_2018',
+            status=Panorama.STATUS.done,
+            timestamp=datetime.datetime(2018, 5, 5, tzinfo=UTC_TZ),
+            filename=factory.fuzzy.FuzzyText(length=30),
+            path=factory.fuzzy.FuzzyText(length=30),
+            geolocation=Point(4.897071, 52.377956, 10),
+            roll=factory.fuzzy.FuzzyFloat(-10, 10),
+            pitch=factory.fuzzy.FuzzyFloat(-10, 10),
+            heading=factory.fuzzy.FuzzyFloat(-10, 10),
+            mission_distance=5.0,
+            mission_year=2018,
+            mission_type='woz',
+            tags=[]
+        )
+        super().setUpClass()
+
     def test_get_thumbnail_returns_json(self):
         response = self.client.get(
-            '/panorama/thumbnail/?lat=52.377956&lon=4.897070&radius=1000')
+            '/panorama/thumbnail/?lat=52.377956&lon=4.897070&radius=100')
         self.assertEqual(response.status_code, 200)
         self.assertIn('pano_id', response.data)
         self.assertIn('url', response.data)

--- a/web/panorama/panorama/tests/test_api_thumbnail.py
+++ b/web/panorama/panorama/tests/test_api_thumbnail.py
@@ -12,26 +12,6 @@ from datasets.panoramas.tests import factories
 
 class ThumbnailApiTest(PanoramaApiTest):
 
-    @classmethod
-    def setUpClass(cls):
-        # Adding locations
-        factories.PanoramaFactory.create(
-            pano_id='PANO_WOZ_2018',
-            status=Panorama.STATUS.done,
-            timestamp=datetime.datetime(2018, 5, 5, tzinfo=UTC_TZ),
-            filename=factory.fuzzy.FuzzyText(length=30),
-            path=factory.fuzzy.FuzzyText(length=30),
-            geolocation=Point(4.897071, 52.377956, 10),
-            roll=factory.fuzzy.FuzzyFloat(-10, 10),
-            pitch=factory.fuzzy.FuzzyFloat(-10, 10),
-            heading=factory.fuzzy.FuzzyFloat(-10, 10),
-            mission_distance=5.0,
-            mission_year=2018,
-            mission_type='woz',
-            tags=[]
-        )
-        super().setUpClass()
-
     def test_get_thumbnail_returns_json(self):
         response = self.client.get(
             '/panorama/thumbnail/?lat=52.377956&lon=4.897070&radius=100')

--- a/web/panorama/panorama/tests/test_batch.py
+++ b/web/panorama/panorama/tests/test_batch.py
@@ -82,6 +82,7 @@ class ImportPanoTest(TransactionTestCase):
         self.assertEqual(Mission.objects.filter(mission_year='2017', mission_type='bi').count(), 0)
 
         panos = Panorama.done.all()
+        log.warning(f"panos: {[pano.pano_id for pano in panos]}")
         self.assertEqual(panos.count(), 16)
 
         self.assertIsNotNone(panos[0]._geolocation_2d_rd)
@@ -126,7 +127,6 @@ class ImportPanoTest(TransactionTestCase):
 
         recent = RecentPanorama.objects.all()
         self.assertEqual(recent.count(), 9)
-
 
     def test_panoramarow_sets_status(self, *args):
         mission = Mission()

--- a/web/panorama/panorama/tests/test_batch.py
+++ b/web/panorama/panorama/tests/test_batch.py
@@ -125,7 +125,7 @@ class ImportPanoTest(TransactionTestCase):
         self.assertIn('mission-2017', Panorama.objects.filter(pano_id='TMX7315120208-000073_pano_0004_000087')[0].tags)
 
         recent = RecentPanorama.objects.all()
-        self.assertEqual(recent.count(), 14)
+        self.assertEqual(recent.count(), 9)
 
 
     def test_panoramarow_sets_status(self, *args):

--- a/web/panorama/panorama/view_imgs.py
+++ b/web/panorama/panorama/view_imgs.py
@@ -7,7 +7,7 @@ from rest_framework.response import Response
 from rest_framework.reverse import reverse
 from scipy import misc
 
-from datasets.panoramas.models import Panorama
+from datasets.panoramas.models import Panorama, RecentPanorama
 from datasets.panoramas.serializers import ThumbnailSerializer
 from panorama.transform.thumbnail import Thumbnail
 from panorama.views import RecentPanoramaViewSet
@@ -56,6 +56,7 @@ class ThumbnailViewSet(RecentPanoramaViewSet):
         aspect: aspect ratio of thumbnail (width/height, min 1) (default 1.5 (3/2)
     """
 
+    queryset = RecentPanorama.objects.all()
     lookup_field = 'pano_id'
     renderer_classes = (renderers.JSONRenderer, renderers.BrowsableAPIRenderer, ImgRenderer)
 

--- a/web/panorama/panorama/views.py
+++ b/web/panorama/panorama/views.py
@@ -103,6 +103,6 @@ class PanoramaViewSet(rest.DatapuntViewSet):
 
 
 class RecentPanoramaViewSet(PanoramaViewSet):
-    queryset = RecentPanorama.done.all()
+    queryset = RecentPanorama.objects.all()
     serializer_class = serializers.RecentPanoSerializer
     serializer_detail_class = serializers.RecentPanoDetailSerializer


### PR DESCRIPTION
After adding the possibility to distinguish mission types and other parameters
in panorama's the subset of recent panoramas should be restricted to the
default set only. This fixes that