### PR TITLE
Create increments for missions

### DIFF
--- a/web/panorama/panorama/etl/batch_import.py
+++ b/web/panorama/panorama/etl/batch_import.py
@@ -3,10 +3,8 @@ import csv
 
 from datasets.panoramas.models import Mission, Panorama
 from panorama.etl.data_to_model import process_mission_row, process_panorama_row
+from panorama.etl.etl_settings import BATCH_SIZE
 from panorama.shared.object_store import ObjectStore
-
-EMPTY_FALLBACK_YEAR = 2000
-BATCH_SIZE = 50000
 
 log = logging.getLogger(__name__)
 objectstore = ObjectStore()

--- a/web/panorama/panorama/etl/check_objectstore.py
+++ b/web/panorama/panorama/etl/check_objectstore.py
@@ -2,14 +2,9 @@ import logging
 from swiftclient import ClientException
 
 from datasets.panoramas.models import EQUIRECTANGULAR_SUBPATH, FULL_IMAGE_NAME
+from panorama.etl.etl_settings import DUMP_FILENAME, SOURCE_LISTING_NAME, INTERMEDIATE_LISTING_NAME, BLURRED_LISTING_NAME, \
+    INCREMENTS_CONTAINER, INTERMEDIATE_CONTAINER
 from panorama.shared.object_store import ObjectStore
-
-SOURCE_LISTING_NAME = "sources.txt"
-INTERMEDIATE_LISTING_NAME = "intermediate.txt"
-BLURRED_LISTING_NAME = "blurred.txt"
-
-INCREMENTS_CONTAINER = "increments"
-INTERMEDIATE_CONTAINER = "intermediate"
 
 panorama_images = {}
 panorama_rendered = {}
@@ -140,6 +135,16 @@ def set_uptodate_info(container, path):
 
     objectstore.put_into_panorama_store(INCREMENTS_CONTAINER, f"{container}/{path}{BLURRED_LISTING_NAME}",
                                         blurred_listing, "text/plain")
+
+
+def increment_exists(increment_path):
+    """Check if an increment is present at the given path
+
+    :param increment_path: the path to check for existince of increment
+    :return: True or False, depending on if the path contains an increment
+    """
+    dirlist = objectstore.get_panorama_store_objects(INCREMENTS_CONTAINER, f"{increment_path}")
+    return f"{increment_path}{DUMP_FILENAME}" in [obj['name'] for obj in dirlist]
 
 
 def is_increment_uptodate(container, path):

--- a/web/panorama/panorama/etl/data_to_model.py
+++ b/web/panorama/panorama/etl/data_to_model.py
@@ -4,11 +4,11 @@ import logging
 from django.contrib.gis.geos import Point
 
 from datasets.panoramas.models import Mission, Panorama
+from panorama.batch import EMPTY_FALLBACK_YEAR
 from panorama.etl.check_objectstore import panorama_image_file_exists, panorama_blurred_file_exists, \
     panorama_rendered_file_exists
 from panorama.etl.date_util import _convert_gps_time
 
-EMPTY_FALLBACK_YEAR = 2000
 log = logging.getLogger(__name__)
 
 

--- a/web/panorama/panorama/etl/db_actions.py
+++ b/web/panorama/panorama/etl/db_actions.py
@@ -1,13 +1,15 @@
 import io
+import logging
 
+from django.core.management.color import no_style
 from django.db import connection
 # from django.db.models.functions import ExtractYear, ExtractMonth, ExtractDay, Substr
 
 from datasets.panoramas.models import Panorama
-from panorama.etl.check_objectstore import INCREMENTS_CONTAINER
+from panorama.etl.etl_settings import DUMP_FILENAME, INCREMENTS_CONTAINER
 from panorama.shared.object_store import ObjectStore
 
-DUMP_FILENAME = "increment.dump"
+log = logging.getLogger(__name__)
 objectstore = ObjectStore()
 
 
@@ -22,6 +24,7 @@ def dump_mission(container, mission_path):
     :param mission_path: mission path to dump
     :return: None
     """
+
     fields = [field.name for field in Panorama._meta.get_fields() if field.name != 'id']
     table_name = Panorama._meta.db_table
 
@@ -47,50 +50,79 @@ def dump_mission(container, mission_path):
                                             "binary/octet-stream")
 
 
-def restore_data(container, mission_path):
-    """Restores the panorama data of a mission from the objectstore:
+def dump_increment(increment_path):
+    """Dumps current dataset (no filters/where-clause) to the given path.
 
-        restore_data("2016", "03/30/TMX315120208-0000023/")
-
-    will read the file 2016/03/30/TMX315120208-0000023/increment.dump into the database
-
-    :param container: container (= year part of the path) to choose data from
-    :param mission_path: mission path to dump
+    :param increment_path: the path the dataset needs to be dumped to
     :return: None
     """
+
+    fields = [field.name for field in Panorama._meta.get_fields() if field.name != 'id']
+    table_name = Panorama._meta.db_table
+
+    base_query = f"SELECT {', '.join(fields)} FROM {table_name}"
+    order_clause = " ORDER BY pano_id ASC"
+
+    with connection.cursor() as cursor:
+        # create the custom copy command
+        copy_command = f"COPY ({base_query+order_clause}) TO STDOUT WITH (FORMAT binary)"
+
+        outputstream = io.BytesIO()
+
+        cursor.copy_expert(copy_command, outputstream)
+        objectstore.put_into_panorama_store(INCREMENTS_CONTAINER,
+                                            f"{increment_path}{DUMP_FILENAME}",
+                                            outputstream.getvalue(),
+                                            "binary/octet-stream")
+
+
+def restore_increment(increment_path):
+    """Restores the panorama data of a mission from the objectstore:
+
+        restore_data("2016/03/30/TMX315120208-0000023/")
+
+    will read the file `2016/03/30/TMX315120208-0000023/increment.dump` into the database
+
+    :param increment_path: increment path to restore
+    :return: None
+    """
+
     fields = [field.name for field in Panorama._meta.get_fields() if field.name != 'id']
     table_name = Panorama._meta.db_table
 
     copy_command = f"COPY {table_name} ({', '.join(fields)}) FROM  STDIN (FORMAT binary)"
     file = io.BytesIO(objectstore.get_panorama_store_object({'container': INCREMENTS_CONTAINER,
-                                                             'name': f"{container}/{mission_path}{DUMP_FILENAME}"}))
+                                                             'name': f"{increment_path}{DUMP_FILENAME}"}))
     with connection.cursor() as cursor:
         cursor.copy_expert(copy_command, file)
 
 
-# def write_increments():
-#
-#     nested_increments = [
-#         {'year': ExtractYear('timestamp')},
-#         {'month': ExtractMonth('timestamp')},
-#         {'day': ExtractDay('timestamp')},
-#         {'mission': Substr('pano_id', 1, 20)},
-#     ]
-#
-#     for i in range(1, len(nested_increments)+1):
-#         annotate = {k: v for item in nested_increments[0:i] for k, v in item.items()}
-#         values = [k for item in nested_increments[0:i] for k, _ in item.items()]
-#
-#         queryset = Panorama.objects.annotate(**annotate).order_by(*values).values(*values).distinct()
-#
-#         for p in queryset:
-#             nested_parts = [str(p[field]) for field in values]
-#             filename = "_".join(nested_parts)
-#             print(f"filename: {filename}.dump")
-#
-#             filters = {field: p[field] for field in values}
-#             fields = [field.name for field in Panorama._meta.get_fields() if field.name != 'id']
-#
-#             dataset = Panorama.objects.annotate(**annotate).filter(**filters).values(*fields).all()
-#
-#             print(f"sql: {dataset.query}")
+def clear_database():
+    """Clear the models from the database
+
+    :return: None
+    """
+    Panorama.objects.all().delete()
+
+
+def reset_sequences():
+    """Reset the sequence, so that after restore of the root increment, the id's start with 1
+
+    :return: None
+    """
+    sequence_sql = connection.ops.sequence_reset_sql(no_style(), [Panorama])
+    with connection.cursor() as cursor:
+        for sql in sequence_sql:
+            cursor.execute(sql)
+
+
+def restore_all():
+    """Rebuild the complete database from the root increment
+
+    :return: None
+    """
+    clear_database()
+    reset_sequences()
+
+    # restore root increment:
+    restore_increment("")

--- a/web/panorama/panorama/etl/etl_settings.py
+++ b/web/panorama/panorama/etl/etl_settings.py
@@ -1,0 +1,9 @@
+"""Some shared constants for ETL"""
+
+BATCH_SIZE = 50000
+DUMP_FILENAME = "increment.dump"
+SOURCE_LISTING_NAME = "sources.txt"
+INTERMEDIATE_LISTING_NAME = "intermediate.txt"
+BLURRED_LISTING_NAME = "blurred.txt"
+INCREMENTS_CONTAINER = "increments"
+INTERMEDIATE_CONTAINER = "intermediate"

--- a/web/panorama/panorama/management/commands/import_increments.py
+++ b/web/panorama/panorama/management/commands/import_increments.py
@@ -4,16 +4,16 @@ from django.core.management import BaseCommand
 
 from panorama.etl.batch_import import rebuild_mission, import_mission_metadata
 from panorama.etl.check_objectstore import set_uptodate_info
-from panorama.etl.db_actions import dump_mission  # , write_increments, restore_data
-from panorama.etl.increments import check_increments
+from panorama.etl.db_actions import dump_mission, restore_all  # , write_increments, restore_data
+from panorama.etl.increments import check_increments, rebuild_increments_recursively
 
 log = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
     def add_arguments(self, parser):
-        parser.add_argument('increment', type=str, help="The increment to import (examples: '2016', '2016/01/', "
-                                                        "'2017/02/03/' or even '2017/05/04/TMX000321015-00030/)")
+        parser.add_argument('--increment', type=str, help="The increment to import (examples: '2016', '2016/01/', "
+                                                          "'2017/02/03/' or even '2017/05/04/TMX000321015-00030/)")
 
     @staticmethod
     def _check_increment(increment):
@@ -38,13 +38,13 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         increment = self._check_increment(options['increment']) if 'increment' in options else None
 
-        up_to_date, missions_to_rebuild = check_increments(increment=increment)
-        if up_to_date:
-            log.info("Everything still up to date")
-            return
+        _, missions_to_rebuild = check_increments(increment=increment)
 
         import_mission_metadata()
         for container, mission_path in missions_to_rebuild:
             rebuild_mission(container, mission_path)
             dump_mission(container, mission_path)
             set_uptodate_info(container, mission_path)
+
+        rebuild_increments_recursively()
+        restore_all()


### PR DESCRIPTION
When all increments for missions are created, they will be bundled
incrementally (per day, per month, per year, over-all) and finally
imported into the database