### PR TITLE
DS-416 Fix geoselection for panorama.

### DIFF
--- a/web/panorama/panorama/views.py
+++ b/web/panorama/panorama/views.py
@@ -186,6 +186,7 @@ class PanoramaFilter(FilterSet):
 
         exists = queryset.model.objects \
             .values('id') \
+            .filter(status='done') \
             .filter(surface_type=OuterRef('surface_type')) \
             .filter(timestamp__gt=OuterRef('timestamp')) \
             .annotate(within=Func(RawCol(queryset.model, '_geolocation_2d_rd'), F('_geolocation_2d_rd'), \


### PR DESCRIPTION
The most recent panorama in region is select, close to the selected point.
However, when selectin newer panoramas that do not exist we should only consider
panorama's with 'done' status, because we return only panaoramas with 'done'.
Otherwise panorama X_2019 is discarded because a newer panorama X_2020 exists with 'rendered' status,
but that panorama is not returned because it has not the 'done' status
status. This is also consistent with the map server layer query